### PR TITLE
Add CI builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+version: "{branch}-ci-{build}"
+image: Visual Studio 2015
+
+branches:
+  only:
+  - master
+
+environment:
+  matrix:
+# - build: msvc
+  - build: cygwin
+
+build_script:
+- call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat"
+- devenv.exe /upgrade mdsp.sln
+- dir
+- PATH=C:\cygwin\bin\;c:\buildbot\bin;%PATH%
+
+test_script:
+- cd tests
+- if "%build%"=="msvc" .\run_msvs2008_tests.cmd this
+- if "%build%"=="cygwin" bash mdsp_test_suite.sh this

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+notifications:
+  email: false
+
+language: cpp
+
+branches:
+  only:
+  - master
+
+compiler:
+  - gcc
+  - clang
+os:
+  - linux
+
+script:
+  - cd tests
+  - ./mdsp_test_suite.sh this

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-| <font color='red' size='5'> Attention!</font><font size='5'> This project is temporally frozen.<br> All education activity is moved to the new project of <a href='http://ilab.fizteh.ru'>Intel lab's</a> called <a href='http://code.google.com/p/uarch-sim/'>uArchSim</a>.</br></font> |
+[![Build Status](https://travis-ci.com/MIPT-ILab/mdsp.svg?branch=master)](https://travis-ci.com/MIPT-ILab/mdsp)
+[![Build status](https://ci.appveyor.com/api/projects/status/i3kxms76dvsnur2n?svg=true)](https://ci.appveyor.com/project/pavelkryukov/mdsp-s7xm7)
+
+| <font color='red' size='5'> Attention!</font><font size='5'> This project is temporally frozen.<br> All education activity is moved to the new project of <a href='https://ilab.fizteh.ru'>Intel lab's</a> called <a href='https://mipt-ilab.github.io/mipt-mips'>uArchSim</a>.</br></font> |
 |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 
@@ -7,15 +10,15 @@
 
 ### Functional and performance simulation of a Multimedia Digital Signal Processor (MDSP) ###
 
-This project is a part of [Intel lab's](http://ilab.fizteh.ru) activity at [Moscow Institute of Physics and Technology](http://phystech.edu/about/aboutmipt.html) (MIPT). The project is being developed by a group of students under the guidance of Intel employees.
+This project is a part of [Intel lab's](https://ilab.fizteh.ru) activity at [Moscow Institute of Physics and Technology](https://phystech.edu/about/aboutmipt.html) (MIPT). The project is being developed by a group of students under the guidance of Intel employees.
 
 Purpose of the project is to create light version of functional and clock-precise simulators of a microprocessor optimized for digital signal processing (DSP).
 
 Project mentors:
-  * [Alexander Titov](http://code.google.com/u/alexander.igorevich.titov/) (2009--12)
-  * [Ivan Sidorenko](http://code.google.com/u/ivan.b.sidorenko/) (org questions)
-  * [Yuri Baida](http://code.google.com/u/yuri.baida/) (2010--11)
-  * [Grigory Rechistov](http://code.google.com/u/grigory.rechistov/) (2010--11)
-  * [Nikolay Kosarev](http://code.google.com/u/nkosarev/) (2009--10)
+  * [Alexander Titov](https://github.com/alexander-titov) (2009--12)
+  * Ivan Sidorenko (org questions)
+  * [Yuri Baida](https://github.com/megabyde) (2010--11)
+  * [Grigory Rechistov](https://github.com/grigory-rechistov) (2010--11)
+  * Nikolay Kosarev (2009--10)
 
-A friendly project of Intel Lab at MIPT: [MIPT-VIS](http://code.google.com/p/mipt-vis/)
+A friendly project of Intel Lab at MIPT: [MIPT-VIS](https://code.google.com/p/mipt-vis/)


### PR DESCRIPTION
Back in 2010, CI build bot was running on MIPT-ILab server and now the configuration is lost completely,
However, now we can do the same thing on CI build machines instead.